### PR TITLE
Make untagged option as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 [features]
 default = ["use_std"]
 use_std = []
+untagged = []
 
 [package.metadata.release]
 no-dev-version = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub use Either::{Left, Right};
 /// (For representing success or error, use the regular `Result` enum instead.)
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(all(feature = "serde", feature = "untagged"), serde(untagged))]
 pub enum Either<L, R> {
     /// A value of type `L`.
     Left(L),


### PR DESCRIPTION
This patch adds a new feature to configure the Either struct as
untagged, to give more control to users of this library, so it's
possible to control how this is serialized.